### PR TITLE
Fix dead reference link

### DIFF
--- a/src/content/docs/guides/lib/quickstart.md
+++ b/src/content/docs/guides/lib/quickstart.md
@@ -68,7 +68,7 @@ flake's inputs.
 ## Configure Snowfall Lib
 
 Snowfall Lib offers some customization options. The following example details a few
-popular settings. For a full list see [Snowfall Lib Reference](/docs/reference/lib).
+popular settings. For a full list see [Snowfall Lib Reference](/reference/lib).
 
 ```nix
 {


### PR DESCRIPTION
Previously, the link contained a /docs, however this isn't true of the real page. This commit fixes that typo