### PR TITLE
Fix typo in systems.md

### DIFF
--- a/src/content/docs/guides/lib/systems.md
+++ b/src/content/docs/guides/lib/systems.md
@@ -86,7 +86,7 @@ custom value in `specialArgs`.
             ];
 
             # Add a custom value to `specialArgs`.
-            system.hosts.my-host.specialArgs = {
+            systems.hosts.my-host.specialArgs = {
                 my-custom-value = "my-value";
             };
         };


### PR DESCRIPTION
Just fixed a typo in the systems docs that prevented me from using specialArgs.