### PR TITLE
Fix incorrect output of function in reference

### DIFF
--- a/src/content/docs/reference/lib.md
+++ b/src/content/docs/reference/lib.md
@@ -1209,7 +1209,7 @@ is-linux "x86_64-linux"
 Result:
 
 ```nix
-false
+true
 ```
 
 #### `lib.snowfall.system.is-virtual`


### PR DESCRIPTION
Previously, the docs suggested that the is-linux function would output false if presented with x86_64-linux. This was presumably an oversight when copypasting the similar is-darwin function above.

To test that the function outputs x86_64-linux we can use nix-repl:

(in the directory of a flake with Snowfall)

    nix-repl> :lf .
    Added 25 variables.
    nix-repl> lib = inputs.snowfall-lib.mkLib { inputs = inputs // { self = { inherit inputs outputs; }; }; src = ./.; }
    nix-repl> is-linux = lib.snowfall.system.is-linux
    nix-repl> is-linux "x86_64-linux"
    true