### PR TITLE
Fix home documentation : home-manager is a required input

### DIFF
--- a/src/content/docs/guides/lib/homes.md
+++ b/src/content/docs/guides/lib/homes.md
@@ -63,6 +63,11 @@ custom value in `specialArgs`.
 			url = "github:snowfallorg/lib";
 			inputs.nixpkgs.follows = "nixpkgs";
 		};
+
+		home-manager = {
+			url = "github:nix-community/home-manager";
+			inputs.nixpkgs.follows = "nixpkgs";
+		};
 	};
 
 	outputs = inputs:


### PR DESCRIPTION
In order to avoid the following error

```txt
error: In order to create home-manager configurations, you must include `home-manager` as a flake input.
```